### PR TITLE
Refactor to minimize the number of redundant iterations

### DIFF
--- a/__tests__/04_proxyops_spec.ts
+++ b/__tests__/04_proxyops_spec.ts
@@ -12,7 +12,9 @@ describe('single operation', () => {
     p.push('d');
     await Promise.resolve();
     expect(lastOps).toEqual([['set', ['3'], 'd', undefined]]);
-    expect(parseProxyOps(lastOps)).toEqual([['set', 3, 'd', undefined]]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [['set', 3, 'd', undefined]],
+    });
   });
 
   it('unshift', async () => {
@@ -30,7 +32,9 @@ describe('single operation', () => {
       ['set', ['1'], 'a', 'b'],
       ['set', ['0'], 'd', 'a'],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([['insert', 0, 'd', undefined]]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [['insert', 0, 'd', undefined]],
+    });
   });
 
   it('pop', async () => {
@@ -46,7 +50,9 @@ describe('single operation', () => {
       ['delete', ['2'], 'c'],
       ['set', ['length'], 2, 3],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([['delete', 2, 'c', undefined]]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [['delete', 2, 'c', undefined]],
+    });
   });
 
   it('shift', async () => {
@@ -64,7 +70,9 @@ describe('single operation', () => {
       ['delete', ['2'], 'c'],
       ['set', ['length'], 2, 3],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([['delete', 0, 'a', undefined]]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [['delete', 0, 'a', undefined]],
+    });
   });
 
   it('splice 0 1', async () => {
@@ -82,7 +90,9 @@ describe('single operation', () => {
       ['delete', ['2'], 'c'],
       ['set', ['length'], 2, 3],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([['delete', 0, 'a', undefined]]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [['delete', 0, 'a', undefined]],
+    });
   });
 
   it('splice 0 2', async () => {
@@ -101,10 +111,12 @@ describe('single operation', () => {
       ['delete', ['2'], 'c'],
       ['set', ['length'], 2, 4],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([
-      ['delete', 1, 'b', undefined],
-      ['delete', 0, 'a', undefined],
-    ]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [
+        ['delete', 1, 'b', undefined],
+        ['delete', 0, 'a', undefined],
+      ],
+    });
   });
 
   it('splice 1 1', async () => {
@@ -122,7 +134,9 @@ describe('single operation', () => {
       ['delete', ['3'], 'd'],
       ['set', ['length'], 3, 4],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([['delete', 1, 'b', undefined]]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [['delete', 1, 'b', undefined]],
+    });
   });
 
   it('splice 1 2', async () => {
@@ -140,10 +154,12 @@ describe('single operation', () => {
       ['delete', ['2'], 'c'],
       ['set', ['length'], 2, 4],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([
-      ['delete', 2, 'c', undefined],
-      ['delete', 1, 'b', undefined],
-    ]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [
+        ['delete', 2, 'c', undefined],
+        ['delete', 1, 'b', undefined],
+      ],
+    });
   });
 
   it('splice 2 2', async () => {
@@ -162,10 +178,12 @@ describe('single operation', () => {
       ['delete', ['4'], 'e'],
       ['set', ['length'], 4, 6],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([
-      ['delete', 3, 'd', undefined],
-      ['delete', 2, 'c', undefined],
-    ]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [
+        ['delete', 3, 'd', undefined],
+        ['delete', 2, 'c', undefined],
+      ],
+    });
   });
 
   it('splice 1 3', async () => {
@@ -185,11 +203,13 @@ describe('single operation', () => {
       ['delete', ['3'], 'd'],
       ['set', ['length'], 3, 6],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([
-      ['delete', 3, 'd', undefined],
-      ['delete', 2, 'c', undefined],
-      ['delete', 1, 'b', undefined],
-    ]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [
+        ['delete', 3, 'd', undefined],
+        ['delete', 2, 'c', undefined],
+        ['delete', 1, 'b', undefined],
+      ],
+    });
   });
 
   it('splice 1 0 d', async () => {
@@ -206,7 +226,9 @@ describe('single operation', () => {
       ['set', ['2'], 'b', 'c'],
       ['set', ['1'], 'd', 'b'],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([['insert', 1, 'd', undefined]]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [['insert', 1, 'd', undefined]],
+    });
   });
 
   it('splice 1 0 d e', async () => {
@@ -224,10 +246,12 @@ describe('single operation', () => {
       ['set', ['1'], 'd', 'b'],
       ['set', ['2'], 'e', 'c'],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([
-      ['insert', 1, 'd', undefined],
-      ['insert', 2, 'e', undefined],
-    ]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [
+        ['insert', 1, 'd', undefined],
+        ['insert', 2, 'e', undefined],
+      ],
+    });
   });
 
   it('splice 1 0 d e f', async () => {
@@ -246,11 +270,13 @@ describe('single operation', () => {
       ['set', ['2'], 'e', 'c'],
       ['set', ['3'], 'f', undefined],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([
-      ['insert', 1, 'd', undefined],
-      ['insert', 2, 'e', undefined],
-      ['set', 3, 'f', undefined],
-    ]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [
+        ['insert', 1, 'd', undefined],
+        ['insert', 2, 'e', undefined],
+        ['set', 3, 'f', undefined],
+      ],
+    });
   });
 
   it('splice 1 1 e f g', async () => {
@@ -269,11 +295,13 @@ describe('single operation', () => {
       ['set', ['2'], 'f', 'c'],
       ['set', ['3'], 'g', 'd'],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([
-      ['set', 1, 'e', 'b'],
-      ['insert', 2, 'f', undefined],
-      ['insert', 3, 'g', undefined],
-    ]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [
+        ['set', 1, 'e', 'b'],
+        ['insert', 2, 'f', undefined],
+        ['insert', 3, 'g', undefined],
+      ],
+    });
   });
 
   it('splice 1 1 e f g with 5 initial items', async () => {
@@ -293,11 +321,13 @@ describe('single operation', () => {
       ['set', ['2'], 'f', 'c'],
       ['set', ['3'], 'g', 'd'],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([
-      ['set', 1, 'e', 'b'],
-      ['insert', 2, 'f', undefined],
-      ['insert', 3, 'g', undefined],
-    ]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [
+        ['set', 1, 'e', 'b'],
+        ['insert', 2, 'f', undefined],
+        ['insert', 3, 'g', undefined],
+      ],
+    });
   });
 
   it('splice 1 2 e f g', async () => {
@@ -315,11 +345,13 @@ describe('single operation', () => {
       ['set', ['2'], 'f', 'c'],
       ['set', ['3'], 'g', 'd'],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([
-      ['set', 1, 'e', 'b'],
-      ['set', 2, 'f', 'c'],
-      ['insert', 3, 'g', undefined],
-    ]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [
+        ['set', 1, 'e', 'b'],
+        ['set', 2, 'f', 'c'],
+        ['insert', 3, 'g', undefined],
+      ],
+    });
   });
 
   it('splice -1 1', async () => {
@@ -335,7 +367,9 @@ describe('single operation', () => {
       ['delete', ['2'], 'c'],
       ['set', ['length'], 2, 3],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([['delete', 2, 'c', undefined]]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [['delete', 2, 'c', undefined]],
+    });
   });
 
   it('splice -2 1', async () => {
@@ -352,7 +386,9 @@ describe('single operation', () => {
       ['delete', ['2'], 'c'],
       ['set', ['length'], 2, 3],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([['delete', 1, 'b', undefined]]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [['delete', 1, 'b', undefined]],
+    });
   });
 
   it('splice -2 1 d e', async () => {
@@ -369,10 +405,12 @@ describe('single operation', () => {
       ['set', ['1'], 'd', 'b'],
       ['set', ['2'], 'e', 'c'],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([
-      ['set', 1, 'd', 'b'],
-      ['insert', 2, 'e', undefined],
-    ]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [
+        ['set', 1, 'd', 'b'],
+        ['insert', 2, 'e', undefined],
+      ],
+    });
   });
 });
 
@@ -391,10 +429,12 @@ describe('double operations', () => {
       ['set', ['3'], 'd', undefined],
       ['set', ['4'], 'e', undefined],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([
-      ['set', 3, 'd', undefined],
-      ['set', 4, 'e', undefined],
-    ]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [
+        ['set', 3, 'd', undefined],
+        ['set', 4, 'e', undefined],
+      ],
+    });
   });
 
   it('unshift and unshift', async () => {
@@ -418,10 +458,12 @@ describe('double operations', () => {
       ['set', ['1'], 'd', 'a'],
       ['set', ['0'], 'e', 'd'],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([
-      ['insert', 0, 'd', undefined],
-      ['insert', 0, 'e', undefined],
-    ]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [
+        ['insert', 0, 'd', undefined],
+        ['insert', 0, 'e', undefined],
+      ],
+    });
   });
 
   it('push and pop', async () => {
@@ -439,10 +481,12 @@ describe('double operations', () => {
       ['delete', ['3'], 'd'],
       ['set', ['length'], 3, 4],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([
-      ['set', 3, 'd', undefined],
-      ['delete', 3, 'd', undefined],
-    ]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [
+        ['set', 3, 'd', undefined],
+        ['delete', 3, 'd', undefined],
+      ],
+    });
   });
 
   it('pop and push', async () => {
@@ -460,10 +504,12 @@ describe('double operations', () => {
       ['set', ['length'], 2, 3],
       ['set', ['2'], 'd', undefined],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([
-      ['delete', 2, 'c', undefined],
-      ['set', 2, 'd', undefined],
-    ]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [
+        ['delete', 2, 'c', undefined],
+        ['set', 2, 'd', undefined],
+      ],
+    });
   });
 
   it('unshift and shift', async () => {
@@ -487,10 +533,12 @@ describe('double operations', () => {
       ['delete', ['3'], 'c'],
       ['set', ['length'], 3, 4],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([
-      ['insert', 0, 'd', undefined],
-      ['delete', 0, 'd', undefined],
-    ]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [
+        ['insert', 0, 'd', undefined],
+        ['delete', 0, 'd', undefined],
+      ],
+    });
   });
 
   it('shift and unshift', async () => {
@@ -512,10 +560,12 @@ describe('double operations', () => {
       ['set', ['1'], 'b', 'c'],
       ['set', ['0'], 'd', 'b'],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([
-      ['delete', 0, 'a', undefined],
-      ['insert', 0, 'd', undefined],
-    ]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [
+        ['delete', 0, 'a', undefined],
+        ['insert', 0, 'd', undefined],
+      ],
+    });
   });
 
   it('pop and pop', async () => {
@@ -534,10 +584,12 @@ describe('double operations', () => {
       ['delete', ['1'], 'b'],
       ['set', ['length'], 1, 2],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([
-      ['delete', 2, 'c', undefined],
-      ['delete', 1, 'b', undefined],
-    ]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [
+        ['delete', 2, 'c', undefined],
+        ['delete', 1, 'b', undefined],
+      ],
+    });
   });
 
   it('shift and shift', async () => {
@@ -559,10 +611,12 @@ describe('double operations', () => {
       ['delete', ['1'], 'c'],
       ['set', ['length'], 1, 2],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([
-      ['delete', 0, 'a', undefined],
-      ['delete', 0, 'b', undefined],
-    ]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [
+        ['delete', 0, 'a', undefined],
+        ['delete', 0, 'b', undefined],
+      ],
+    });
   });
 
   it('splice 1 0 and splice 1 0', async () => {
@@ -583,10 +637,12 @@ describe('double operations', () => {
       ['set', ['3'], 'b', 'c'],
       ['set', ['2'], 'e', 'b'],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([
-      ['insert', 1, 'd', undefined],
-      ['insert', 2, 'e', undefined],
-    ]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [
+        ['insert', 1, 'd', undefined],
+        ['insert', 2, 'e', undefined],
+      ],
+    });
   });
 
   it('moveUp (#7)', async () => {
@@ -609,10 +665,12 @@ describe('double operations', () => {
       ['set', ['2'], 'b', 'd'],
       ['set', ['1'], 'c', 'b'],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([
-      ['delete', 2, 'c', undefined],
-      ['insert', 1, 'c', undefined],
-    ]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [
+        ['delete', 2, 'c', undefined],
+        ['insert', 1, 'c', undefined],
+      ],
+    });
   });
 
   it('moveDown (#7)', async () => {
@@ -633,9 +691,11 @@ describe('double operations', () => {
       ['set', ['4'], 'e', undefined],
       ['set', ['3'], 'c', 'e'],
     ]);
-    expect(parseProxyOps(lastOps)).toEqual([
-      ['delete', 2, 'c', undefined],
-      ['insert', 3, 'c', undefined],
-    ]);
+    expect(parseProxyOps(lastOps)).toEqual({
+      '': [
+        ['delete', 2, 'c', undefined],
+        ['insert', 3, 'c', undefined],
+      ],
+    });
   });
 });


### PR DESCRIPTION
I was going through the code and noticed that `SubscribeP` function and `parseProxyOps` are a bit confusing as there are redundant iterations going on there.

`parseProxyOps` works on the whole set of operations, but those could be related to different paths, yet it's still being called multiple times for each operation.

The refactor makes sure `parseProxyOps` is called one time. And arrayOps are processed on a per path basis.

