### PR TITLE
fix: support mutation on length prop to shrink or extend arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix: support mutation on the length property directly to shrink or extend arrays #51
+
 ## [0.6.0] - 2024-06-04
 
 ### Changed

--- a/tests/04_proxyops.spec.ts
+++ b/tests/04_proxyops.spec.ts
@@ -641,4 +641,19 @@ describe('double operations', () => {
       ['insert', 3, 'c', undefined],
     ]);
   });
+
+  it('support mutations on length', async () => {
+    const p = proxy(['a', 'b', 'c']);
+    let lastOps: any;
+    subscribe(p, (ops) => {
+      lastOps = ops;
+    });
+
+    p.length = 2;
+    await Promise.resolve();
+    expect(lastOps).toEqual([['set', ['length'], 2, 3]]);
+    expect(parseProxyOps(lastOps)).toEqual([
+      ['delete', 2, undefined, undefined],
+    ]);
+  });
 });

--- a/tests/10_length_mutation.spec.ts
+++ b/tests/10_length_mutation.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import * as Y from 'yjs';
+import { proxy } from 'valtio/vanilla';
+import { bind } from 'valtio-yjs';
+
+describe('array length reset', () => {
+  it('reset then push', async () => {
+    const p = proxy<string[]>([]);
+    const doc = new Y.Doc();
+    const m = doc.getMap('map');
+    const a = new Y.Array();
+    m.set('arr', a);
+    bind(p, a);
+
+    p.push('a');
+    p.push('b');
+    p.length = 0;
+    p.push('b');
+    await Promise.resolve();
+
+    expect(a.toJSON()).toEqual(['b']);
+    expect(p).toEqual(['b']);
+  });
+
+  it('shrink then push', async () => {
+    const p = proxy(['a', 'b', 'c']);
+    const doc = new Y.Doc();
+    const a = doc.getArray('arr');
+    bind(p, a);
+
+    p.length = 2;
+    await Promise.resolve();
+
+    expect(a.toJSON()).toEqual(['a', 'b']);
+    expect(p).toEqual(['a', 'b']);
+
+    p.push('c');
+    await Promise.resolve();
+
+    expect(a.toJSON()).toEqual(['a', 'b', 'c']);
+    expect(p).toEqual(['a', 'b', 'c']);
+  });
+
+  it('extend', async () => {
+    const p: string[] = proxy([]);
+    const doc = new Y.Doc();
+    const a = doc.getArray('arr');
+    bind(p, a);
+    p.push('a', 'b', 'c');
+    await Promise.resolve();
+    p.length = 5;
+    p[4] = 'e';
+    await Promise.resolve();
+    expect(p.toString()).toEqual('a,b,c,,e');
+    expect(a.toJSON()).toEqual(['a', 'b', 'c', null, 'e']);
+  });
+});


### PR DESCRIPTION
Hi @dai-shi, this should fix #51.

The array length mutation issue was caused by the lack of support for `["set", ["length"], ..]` ops in src/parseProxyOps.ts.
For instance, the array was shrunk, but changes weren't correctly replicated on YJS, so after changes were applied, YJS called the observer callback, which checked if the two objects were identical, and as they weren't, this triggered an infinite YJS <=> Valtio callback recursion.

We have two cases:

1. Length is set to a lower value than the actual array size
   - we need to emit several delete ops.
   - but if the set-length op is preceded by a true delete op (as emitted by `arr.pop()` for instance), then it shouldn't count, since Valtio's final `["set", ["length"], ..]` ops are redundant.
   - so we subtract the number of delete ops from the oldLength - newLength, to avoid over-deleting.

2. Length is higher than the actual array size

   - This can happen when users want to allocate more size in the array.
   - We emit multiple insert ops at the end of the array.
   - We face an issue here, since setting arr.length creates undefined items in the array, but YJS cannot represent the undefined type, so there would be no way to match the two collections, again triggering an infinite JS <=> Valtio callback recursion.
   - To solve this, we convert these undefined values to null, and vendor/adapt the `deepEqual` method to allow null on the YJS side when the proxy value is either null or undefined.