### PR TITLE
fix toYValue throws error for undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,10 @@ const transact = (doc: Y.Doc | null, opts: Options, fn: () => void) => {
 };
 
 const toYValue = (val: any) => {
+  if (val === undefined) {
+    return undefined;
+  }
+
   if (isProxyArray(val)) {
     const arr = new Y.Array();
     arr.insert(

--- a/tests/07_nested_map.spec.ts
+++ b/tests/07_nested_map.spec.ts
@@ -222,6 +222,15 @@ describe('issue #14', () => {
       },
     });
   });
+
+  it('nested map with undefined value', async () => {
+    const doc = new Y.Doc();
+    const p = proxy<{ a?: { b: number; c: string | undefined } }>({});
+    bind(p, doc.getMap());
+    p.a = { b: 1, c: undefined };
+    await Promise.resolve();
+    expect(doc.getMap().get('a')).toBeDefined();
+  });
 });
 
 describe('issue #56', () => {


### PR DESCRIPTION
Fixes and issue where undefined values throwing exception from toYValue, even if undefined values filtered\handled upper on the call stack.